### PR TITLE
Update v0.5.0

### DIFF
--- a/SOURCES/munit-0.2.0.tar.gz
+++ b/SOURCES/munit-0.2.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58c12f2ae08acfc270d47a5ff23380c300b24d7dc53f3a23f4527e0112146844
+size 23689

--- a/SOURCES/uefistored-0.3.0.tar.gz
+++ b/SOURCES/uefistored-0.3.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13e9e803604a53c29c362233da6280745e4a3d99d85b4cdf8390e68e3c08b5f7
-size 533701

--- a/SOURCES/uefistored-0.5.0.tar.gz
+++ b/SOURCES/uefistored-0.5.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eb112ba9ead86513c2abe692f3c573515427d0d56c953ebee78ce67c0e19611
+size 180424


### PR DESCRIPTION
I renamed the branch name which closed the previous PR (I did not know this would happen), so here is the new one.

This version includes the fix for the bad path to create-auth (uefistored-v0.4.2) and also prevents reaching out to the network
to pull the munit library.

The previous PR is here for reference:
https://github.com/xcp-ng-rpms/uefistored/pull/2

After okay'ing it, I will squash.
