### PR TITLE
Update to v0.5.1

### DIFF
--- a/SOURCES/uefistored-0.5.0.tar.gz
+++ b/SOURCES/uefistored-0.5.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8eb112ba9ead86513c2abe692f3c573515427d0d56c953ebee78ce67c0e19611
-size 180424

--- a/SOURCES/uefistored-0.5.1.tar.gz
+++ b/SOURCES/uefistored-0.5.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc4c5f17b916dea48b5763233f4643b0cbc9040b83b8e6b9759cf24630fe18cc
+size 180536

--- a/SPECS/uefistored.spec
+++ b/SPECS/uefistored.spec
@@ -1,5 +1,5 @@
 Name:           uefistored
-Version:        0.5.0
+Version:        0.5.1
 Release:        1%{?dist}
 Summary:        Variables store for UEFI guests
 License:        GPLv2
@@ -85,6 +85,9 @@ make test
 %{_datadir}/varstored/dbx.auth
 
 %changelog
+* Mon Apr 12 2021 Bobby Eshleman <bobby.eshleman@gmail.com> - 0.5.1-1
+- Update to 0.5.1
+
 * Mon Apr 5 2021 Bobby Eshleman <bobby.eshleman@gmail.com> - 0.5.0-1
 - Update to 0.5.0
 - Add secureboot-certs script


### PR DESCRIPTION
uefistored 0.5.1 adds the MS KEK to be downloaded and installed by secureboot-certs.